### PR TITLE
Include metadata in cut index

### DIFF
--- a/create_index
+++ b/create_index
@@ -1,1 +1,6 @@
-(cd shared/cuts/; ls *.json | sed 's/^/"/ ; s/$/"/') | jq -s '[.]|add' > shared/cuts.json
+(
+  cd shared
+  find cuts -name \*.json |
+    xargs jq 'del(.slicers) | .href = input_filename' |
+    jq --slurp .
+) > shared/cuts.json

--- a/shared/cuts.json
+++ b/shared/cuts.json
@@ -1,8 +1,68 @@
 [
-  "30b6-tiny-cabin-16-pieces-the-pizza-way.json",
-  "96e8-missing-camera-39-pieces-Leaps.json",
-  "b6cd-treehouse-10-pieces-Cluttered-slices.json",
-  "cf46-littlest-tokyo-60-pieces-Coarse-and-delicate.json",
-  "e7d5-shark-cage-47-pieces-Broken-jaws.json",
-  "the-wizards-enigmatic-cabin-laurents-cut.json"
+  {
+    "id": "30b6-tiny-cabin-16-pieces-the-pizza-way",
+    "modelId": "tiny-cabin",
+    "name": "The pizza way",
+    "pieceCount": 16,
+    "pieceSpacing": 0.5,
+    "piecesPerColumn": 4,
+    "author": "Raphaël",
+    "timeToSolve": "4",
+    "href": "cuts/30b6-tiny-cabin-16-pieces-the-pizza-way.json"
+  },
+  {
+    "id": "96e8-missing-camera-39-pieces-Leaps",
+    "modelId": "missing-camera",
+    "name": "Leaps",
+    "pieceCount": "39",
+    "pieceSpacing": 0.5,
+    "piecesPerColumn": 4,
+    "author": "Raphaël",
+    "timeToSolve": "12",
+    "href": "cuts/96e8-missing-camera-39-pieces-Leaps.json"
+  },
+  {
+    "id": "b6cd-treehouse-10-pieces-Cluttered-slices",
+    "modelId": "treehouse",
+    "name": "Cluttered slices",
+    "pieceCount": "10",
+    "pieceSpacing": 0.5,
+    "piecesPerColumn": 4,
+    "author": "Raphaël",
+    "timeToSolve": "5",
+    "href": "cuts/b6cd-treehouse-10-pieces-Cluttered-slices.json"
+  },
+  {
+    "id": "cf46-littlest-tokyo-60-pieces-Coarse-and-delicate",
+    "modelId": "littlest-tokyo",
+    "name": "Coarse and delicate",
+    "pieceSpacing": 0.5,
+    "piecesPerColumn": 4,
+    "pieceCount": "60",
+    "author": "Raphaël",
+    "timeToSolve": "15",
+    "href": "cuts/cf46-littlest-tokyo-60-pieces-Coarse-and-delicate.json"
+  },
+  {
+    "id": "e7d5-shark-cage-47-pieces-Broken-jaws",
+    "modelId": "shark-cage",
+    "name": "Broken jaws",
+    "pieceCount": "47",
+    "pieceSpacing": 0.5,
+    "piecesPerColumn": 4,
+    "author": "Raphaël",
+    "timeToSolve": "12",
+    "href": "cuts/e7d5-shark-cage-47-pieces-Broken-jaws.json"
+  },
+  {
+    "id": "the-wizards-enigmatic-cabin-laurents-cut",
+    "modelId": "the-wizards-enigmatic-cabin",
+    "name": "Laurent's cut",
+    "pieceCount": "32",
+    "pieceSpacing": 0.5,
+    "piecesPerColumn": 4,
+    "author": "Laurent",
+    "timeToSolve": "11",
+    "href": "cuts/the-wizards-enigmatic-cabin-laurents-cut.json"
+  }
 ]

--- a/shared/script.js
+++ b/shared/script.js
@@ -10,11 +10,12 @@ function getJSON(url, callback) {
   xobj.send();
 }
 
-function addCut(filename,url,cut) {
+function addCut(cut) {
   var t = document.querySelector('#line-to-repeat');
   var line = document.importNode(t.content, true);
-  line.querySelectorAll('a')[0].href = url;
-  var cmd = oneliner(filename);
+  line.querySelectorAll('a')[0].href = cut.href;
+  var url = new URL(cut.href, document.location.href).toString();
+  var cmd = oneliner(url, cut.id);
   line.querySelectorAll('a')[1].setAttribute("title", cmd);
   line.querySelectorAll('a')[1].onclick = function(e) {
     copyTextToClipboard(cmd);
@@ -36,19 +37,14 @@ async function copyTextToClipboard(text) {
   }
 }
 
-function oneliner(filename) {
-  return "curl " + document.location.href + '/' + filename + " | adb shell 'cat > /sdcard/Android/data/am.benth.pecopeco/files/PecoPeco/cuts/" + filename + "'"
+function oneliner(url, id) {
+  return "curl " + url + " | adb shell 'cat > /sdcard/Android/data/am.benth.pecopeco/files/PecoPeco/cuts/" + id + ".json'"
 }
 
 document.onreadystatechange = function () {
   if (document.readyState === 'interactive') {
     getJSON('cuts.json', function(cuts) {
-      cuts.forEach(function(filename) {
-        var url='cuts/' + filename;
-        getJSON(url, function(cut) {
-          addCut(filename,url,cut);
-        });
-      });
+      cuts.forEach(addCut);
     });
   }
 }


### PR DESCRIPTION
Instead of listing only the cut IDs, the create_index script now includes the cut metadata (contents of the cut file minus the "slicers" property), and adds an "href" property with a (potentially relative) URL to the actual cut file.

The JavaScript for the index page was adapted to use the info from that index instead of downloading all cut files.

The one-liner generation was adapted to correctly apply the cut's href to the document's base URI, and also to use the cut's ID (which is presumed unique and filename-safe) to name the uploaded JSON file, since we no longer assume the cut has a "filename", just an URL.